### PR TITLE
AQ-94 Fix path parsing in GUI

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -18,7 +18,7 @@ int main(int argc, char *argv[])
     QVariant settingsPath;
 
     if(QFile(configPath).exists()) {
-        settingsPath = "file:///" + configPath;
+        settingsPath = QUrl::fromLocalFile(configPath);
     } else {
         settingsPath = QVariant(QVariant::String);
     }


### PR DESCRIPTION
On `Windows`, experiment with changing https://github.com/MicroscopeIT/aquascope_gui/blob/e22eb69f1c002c46dbbc89984dbe536f7b5e95a8/main.cpp#L14 to:
```
//auto configPath = QDir(applicationPath).filePath("settings.json");
auto configPath = QString("C:\\...\settings.json");
```
or
```
//auto configPath = QDir(applicationPath).filePath("settings.json");
auto configPath = QString("\\\\DESKTOP\\...\\settings.json");
```

On `master` only first works. On this branch both work. 