### PR TITLE
AQ-108 do not select grayed out image

### DIFF
--- a/lib/ImageView.qml
+++ b/lib/ImageView.qml
@@ -158,6 +158,9 @@ Item {
                             anchors.fill: parent
 
                             onClicked: {
+                                if (rect.state == "grayout")
+                                    return
+
                                 item.selected = !item.selected
                                 item = root.model.get(modelData)
                             }


### PR DESCRIPTION
This change make that it is not possible to select grayed out image. But changing filter does not deselect images.