### PR TITLE
Mbodych/debug image view bug aq 114

### DIFF
--- a/lib/ImageView.qml
+++ b/lib/ImageView.qml
@@ -114,6 +114,8 @@ Item {
         listView.forceLayout()
 
         listView.lastY = listView.contentY
+
+        listView.firstIdInTheFirstRow = listView.model.get(listView.indexAt(x_offset_to_content, listView.contentY)).firstIdx
     }
 
     onWidthChanged: timer.restart()
@@ -137,7 +139,7 @@ Item {
         }
 
         onMovementEnded: {
-            firstIdInTheFirstRow = model.get(indexAt(10, contentY)).firstIdx
+            firstIdInTheFirstRow = model.get(indexAt(x_offset_to_content, contentY)).firstIdx
             lastY = contentY
         }
 


### PR DESCRIPTION
It seems that ListView has some optimizations that do not play nice with its contentY property (hence warnings not to use it in the dosc but anyway... :) ). It also seems that to have contentY in reliable step it suffices not to move the view at once by more pixels than currently displayed. Such moving also happens while using the ListView's member functions:
- `positionViewAtBeginning()`
- `positionViewAtEnd()`
- `positionViewAtIndex(int index, PositionMode mode)`

This fix removes the usage of those functions and introduces a graceful contentY setting function that works in steps by at most 100px.

There is also `positionViewAtIndex` replacement that also moves by 100px

forcing layout at the beginning of the update function is crucial, as otherwise zooming can also break contentY

I really tried to break this for a couple of minutes and I did not.