### PR TITLE
URL encoding fixed

### DIFF
--- a/lib/requests.js
+++ b/lib/requests.js
@@ -17,14 +17,14 @@ function encodeQuery(obj) {
             val.forEach(function (value, id_val) {
                 if(result.length !== 0)
                     result += '&'
-                result += key + '=' + encodeURI(value.toString())
+                result += key + '=' + encodeURIComponent(value.toString())
             })
         } else {
 
             if(result.length !== 0)
                 result += '&'
 
-            result += key + '=' + encodeURI(val.toString())
+            result += key + '=' + encodeURIComponent(val.toString())
         }
     })
 


### PR DESCRIPTION
To understand the difference I recommend this documentation:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent

especially the part that starts with `encodeURIComponent differs from encodeURI as follows:`

Problem originally raised (https://github.com/MicroscopeIT/aquascope_gui/pull/71#pullrequestreview-213297732)